### PR TITLE
Upgrade ES & Kibana to 7.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,6 @@ Elasticsearch Index for the [The Movie Database](http://themoviedb.com).
 
 ## Using Docker
 
-### Build containers
-
-With Docker installed, build the containers as below. You only need to do this once.
-
-```
-cd es-docker
-docker build --tag=elasticsearch-tlre .
-cd ../kb-docker
-docker build --tag=kibana-tlre .
-```
-
 ### Run containers
 
 ```
@@ -29,7 +18,7 @@ Browse to http://localhost:9200 and http://localhost:5601 to confirm ES / Kibana
 
 ### Elasticsearch
 
-1. Download [Elasticsearch 6.4.1](https://www.elastic.co/downloads/past-releases/elasticsearch-6-4-1)
+1. Download [Elasticsearch 7.3.1](https://www.elastic.co/downloads/past-releases/elasticsearch-7-3-1)
 2. Unzip to where you'd like to run Elasticsearch
 3. Add the following to config/elasticsearch.yml
 
@@ -39,10 +28,10 @@ http.cors.enabled: true
 indices.query.bool.max_clause_count: 10240
 ```
 
-4. Install the Elasticsearch LTR plugin for 6.4.1:
+4. Install the Elasticsearch LTR plugin for 7.3.1:
 
 ```
-./bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.1.0-es6.4.1.zip
+./bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.1.2-es7.3.1.zip
 ```
 
 5. Run Elasticsearch
@@ -55,14 +44,14 @@ indices.query.bool.max_clause_count: 10240
 
 ### Kibana
 
-1. Download [Kibana 6.4.1](https://www.elastic.co/downloads/past-releases/kibana-6-4-1)
+1. Download [Kibana 7.3.1](https://www.elastic.co/downloads/past-releases/kibana-7-3-1)
 
 2. Unzip to where you'd like to run Kibana
 
 3. Install the [Kibana Analyze Plugin](https://github.com/johtani/analyze-api-ui-plugin)
 
 ```
-./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/6.4.1/analyze-api-ui-plugin-6.4.1.zip 
+./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.3.1/analyze-api-ui-plugin-7.3.1.zip
 ```
 
 4. Run Kibana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,26 @@
 version: '2'
 services:
+
   kibana:
+    build: ./kb-docker
     image: kibana-tlre
     expose:
       - "5601"
     ports:
      - "5601:5601"
     environment:
-      SERVER_HOST: "0.0.0.0"
+      - "SERVER_HOST=0.0.0.0"
+
   elasticsearch:
+    build: ./es-docker
     image: elasticsearch-tlre
     ports:
      - "9200:9200"
     expose:
       - "9200"
     environment:
-      SERVER_NAME: "elasticsearch"
+      - "SERVER_NAME=elasticsearch"
+      - discovery.type=single-node
     volumes:
       - tlre-es-data:/usr/share/elasticsearch/data
 

--- a/es-docker/Dockerfile
+++ b/es-docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.4.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.1
 
-RUN bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.1.0-es6.4.1.zip
+RUN bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.1.2-es7.3.1.zip
 COPY --chown=elasticsearch:elasticsearch elasticsearch.yml /usr/share/elasticsearch/config/
 RUN cat  /usr/share/elasticsearch/config/elasticsearch.yml
 

--- a/indexTmdb.py
+++ b/indexTmdb.py
@@ -39,7 +39,6 @@ def reindex(es, movieDict={}, schema='schema.json', index='tmdb'):
     def bulkDocs(movieDict):
         for movie in indexableMovies():
             addCmd = {"_index": index,
-                      "_type": "movie",
                       "_id": movie['id'],
                       "_source": movie}
             yield addCmd

--- a/kb-docker/Dockerfile
+++ b/kb-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/kibana/kibana:6.4.1
+FROM docker.elastic.co/kibana/kibana:7.3.1
 
-RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/6.4.1/analyze-api-ui-plugin-6.4.1.zip 
+RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.3.1/analyze_api_ui-7.3.1.zip
 

--- a/schema.json
+++ b/schema.json
@@ -1,193 +1,191 @@
 {
   "mappings": {
-    "movie": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms"
-          ]
-        },
-        "tagline": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ]
-        },
-        "directors": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_people",
-            "text_people_max",
-            "text_people2",
-            "text_people_notf",
-            "text_people_notf_front_4",
-            "text_std_gr_idx_syn",
-            "text_people_syn",
-            "text_std_syn",
-            "text_people_gr_idx_syn",
-            "text_std_idioms",
-            "text_people_notf_front",
-            "text_people_bigram"
-          ]
-        },
-        "cast": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_people",
-            "text_people_max",            
-            "text_people2",
-            "text_people_notf",
-            "text_people_notf_front_4",
-            "text_std_gr_idx_syn",
-            "text_people_syn",
-            "text_std_syn",
-            "text_people_gr_idx_syn",
-            "text_std_idioms",
-            "text_people_notf_front",
-            "text_people_bigram"
-          ]
-        },
-        "overview": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ]
-        },
-        "genres": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": [
-            "text_std",
-            "text_all",
-            "text_std_gr_idx_syn",
-            "text_std_syn",
-            "text_std_idioms",
-            "text_std_tax",
-            "text_std_tax_phrase"
-          ],
-          "fielddata": true
-        },
-        "text_all": {
-          "type": "text",
-          "analyzer": "my_english"
-        },
-        "text_people": {
-          "type": "text",
-          "analyzer": "my_english",
-          "fielddata": true,
-          "store": true
-        },
-        "text_people_max": {
-          "type": "text",
-          "analyzer": "max_names",
-          "fielddata": true,
-          "store": true
-        },
-        "text_people_bigram": {
-          "type": "text",
-          "analyzer": "names_bigram",
-          "fielddata": true,
-          "store": true,
-          "similarity": "no_tf_similarity"
-        },
-        "text_std": {
-          "type": "text",
-          "analyzer": "standard",
-          "search_analyzer": "std_syn",
-          "store": true
-        },
-        "text_std_idioms": {
-          "type": "text",
-          "analyzer": "std_idioms",
-          "store": true
-        },
-        "text_std_tax": {
-          "type": "text",
-          "analyzer": "std_tax",
-          "store": true
-        },
-        "text_std_tax_phrase": {
-          "type": "text",
-          "analyzer": "std_tax_phrase_idx",
-          "search_analyzer": "std_tax_phrase_q",
-          "store": true
-        },
-        "text_std_gr_idx_syn": {
-          "type": "text",
-          "analyzer": "std_syn_gr_multiterm",
-          "store": true
-        },
-        "text_people_gr_idx_syn": {
-          "type": "text",
-          "analyzer": "std_syn_gr_multiterm",
-          "store": true
-        },
-        "text_std_syn_mt": {
-          "type": "text",
-          "analyzer": "std_syn_multiterm",
-          "store": true
-        },
-        "text_people_syn_mt": {
-          "type": "text",
-          "analyzer": "std_syn_multiterm",
-          "store": true
-        },
-        "text_std_syn": {
-          "type": "text",
-          "analyzer": "std_syn_bidirect",
-          "store": true
-        },
-        "text_people_syn": {
-          "type": "text",
-          "analyzer": "std_syn_bidirect",
-          "store": true
-        },
-        "text_people2": {
-          "type": "text",
-          "analyzer": "names",
-          "store": true
-        },
-        "text_people_notf": {
-          "type": "text",
-          "analyzer": "names",
-          "similarity": "no_tf_similarity"
-        },
-        "text_people_notf_front": {
-          "type": "text",
-          "analyzer": "names_front",
-          "similarity": "no_tf_similarity"
-        },
-        "text_people_notf_front_4": {
-          "type": "text",
-          "analyzer": "names_front4",
-          "similarity": "no_tf_similarity"
-        }
+    "properties": {
+      "title": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms"
+        ]
+      },
+      "tagline": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ]
+      },
+      "directors": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_people",
+          "text_people_max",
+          "text_people2",
+          "text_people_notf",
+          "text_people_notf_front_4",
+          "text_std_gr_idx_syn",
+          "text_people_syn",
+          "text_std_syn",
+          "text_people_gr_idx_syn",
+          "text_std_idioms",
+          "text_people_notf_front",
+          "text_people_bigram"
+        ]
+      },
+      "cast": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_people",
+          "text_people_max",
+          "text_people2",
+          "text_people_notf",
+          "text_people_notf_front_4",
+          "text_std_gr_idx_syn",
+          "text_people_syn",
+          "text_std_syn",
+          "text_people_gr_idx_syn",
+          "text_std_idioms",
+          "text_people_notf_front",
+          "text_people_bigram"
+        ]
+      },
+      "overview": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ]
+      },
+      "genres": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": [
+          "text_std",
+          "text_all",
+          "text_std_gr_idx_syn",
+          "text_std_syn",
+          "text_std_idioms",
+          "text_std_tax",
+          "text_std_tax_phrase"
+        ],
+        "fielddata": true
+      },
+      "text_all": {
+        "type": "text",
+        "analyzer": "my_english"
+      },
+      "text_people": {
+        "type": "text",
+        "analyzer": "my_english",
+        "fielddata": true,
+        "store": true
+      },
+      "text_people_max": {
+        "type": "text",
+        "analyzer": "max_names",
+        "fielddata": true,
+        "store": true
+      },
+      "text_people_bigram": {
+        "type": "text",
+        "analyzer": "names_bigram",
+        "fielddata": true,
+        "store": true,
+        "similarity": "no_tf_similarity"
+      },
+      "text_std": {
+        "type": "text",
+        "analyzer": "standard",
+        "search_analyzer": "std_syn",
+        "store": true
+      },
+      "text_std_idioms": {
+        "type": "text",
+        "analyzer": "std_idioms",
+        "store": true
+      },
+      "text_std_tax": {
+        "type": "text",
+        "analyzer": "std_tax",
+        "store": true
+      },
+      "text_std_tax_phrase": {
+        "type": "text",
+        "analyzer": "std_tax_phrase_idx",
+        "search_analyzer": "std_tax_phrase_q",
+        "store": true
+      },
+      "text_std_gr_idx_syn": {
+        "type": "text",
+        "analyzer": "std_syn_gr_multiterm",
+        "store": true
+      },
+      "text_people_gr_idx_syn": {
+        "type": "text",
+        "analyzer": "std_syn_gr_multiterm",
+        "store": true
+      },
+      "text_std_syn_mt": {
+        "type": "text",
+        "analyzer": "std_syn_multiterm",
+        "store": true
+      },
+      "text_people_syn_mt": {
+        "type": "text",
+        "analyzer": "std_syn_multiterm",
+        "store": true
+      },
+      "text_std_syn": {
+        "type": "text",
+        "analyzer": "std_syn_bidirect",
+        "store": true
+      },
+      "text_people_syn": {
+        "type": "text",
+        "analyzer": "std_syn_bidirect",
+        "store": true
+      },
+      "text_people2": {
+        "type": "text",
+        "analyzer": "names",
+        "store": true
+      },
+      "text_people_notf": {
+        "type": "text",
+        "analyzer": "names",
+        "similarity": "no_tf_similarity"
+      },
+      "text_people_notf_front": {
+        "type": "text",
+        "analyzer": "names_front",
+        "similarity": "no_tf_similarity"
+      },
+      "text_people_notf_front_4": {
+        "type": "text",
+        "analyzer": "names_front4",
+        "similarity": "no_tf_similarity"
       }
     }
   },
@@ -206,32 +204,35 @@
           "type": "shingle",
           "max_shingle_size": 2,
           "min_shingle_size": 2,
-          "output_unigrams": false},
+          "output_unigrams": false
+        },
         "english_stop": {
           "type": "stop",
           "stopwords": "_english_"
         },
         "english_keywords": {
           "type": "keyword_marker",
-          "keywords": ["maine"]
+          "keywords": [
+            "maine"
+          ]
         },
         "english_stem": {
           "type": "stemmer",
           "language": "english"
         },
-        "custom_stems_override" : {
-            "type" : "stemmer_override",
-            "rules" : [
-                "maine => maine"
-            ]
+        "custom_stems_override": {
+          "type": "stemmer_override",
+          "rules": [
+            "maine => maine"
+          ]
         },
-        "english_minimal_stem" : {
-            "type" : "stemmer",
-            "language" : "minimal_english"
+        "english_minimal_stem": {
+          "type": "stemmer",
+          "language": "minimal_english"
         },
-        "english_light_stem" : {
-            "type" : "stemmer",
-            "language" : "light_english"
+        "english_light_stem": {
+          "type": "stemmer",
+          "language": "light_english"
         },
         "english_possessive_stem": {
           "type": "stemmer",
@@ -295,11 +296,20 @@
         },
         "semantic_keep": {
           "type": "keep",
-          "keep_words": ["science_fiction", "fantasy", "nerddom", "fanfic",
-                         "__science__", "__fiction__",
-                         "__nerd__", "__dom__",
-                         "__fant__", "__asy__",
-                         "__fan__", "__fic__"]
+          "keep_words": [
+            "science_fiction",
+            "fantasy",
+            "nerddom",
+            "fanfic",
+            "__science__",
+            "__fiction__",
+            "__nerd__",
+            "__dom__",
+            "__fant__",
+            "__asy__",
+            "__fan__",
+            "__fic__"
+          ]
         },
         "semantic_expansion": {
           "type": "synonym",
@@ -325,11 +335,11 @@
           ]
         },
         "my_bigram_filter": {
-         "type": "shingle",
-         "max_shingle_size": 2,
-         "min_shingle_size": 2,
-         "output_unigrams": false
-        }          
+          "type": "shingle",
+          "max_shingle_size": 2,
+          "min_shingle_size": 2,
+          "output_unigrams": false
+        }
       },
       "analyzer": {
         "names": {

--- a/schema_basic.json
+++ b/schema_basic.json
@@ -1,16 +1,16 @@
 {
   "mappings": {
-    "movie": {
-      "properties": {
-        "title": {
-          "type": "text"
-        },
-        "overview": {
-          "type": "text",
-          "analyzer": "english"
-  }}}},
+    "properties": {
+      "title": {
+        "type": "text"
+      },
+      "overview": {
+        "type": "text",
+        "analyzer": "english"
+      }
+    }
+  },
   "settings": {
     "number_of_shards": 1
   }
 }
-

--- a/schema_basic_analyzer.json
+++ b/schema_basic_analyzer.json
@@ -1,54 +1,64 @@
 {
   "mappings": {
-    "movie": {
-      "properties": {
-        "title": {
-          "type": "text",
-          "copy_to": "text_all"
-        },
-        "overview": {
-          "type": "text",
-          "analyzer": "my_english",
-          "copy_to": "text_all"
-        },
-        "text_all": {
-          "type": "text",
-          "analyzer": "my_english"
-        }
-  }}},
+    "properties": {
+      "title": {
+        "type": "text",
+        "copy_to": "text_all"
+      },
+      "overview": {
+        "type": "text",
+        "analyzer": "my_english",
+        "copy_to": "text_all"
+      },
+      "text_all": {
+        "type": "text",
+        "analyzer": "my_english"
+      }
+    }
+  },
   "settings": {
-    "analysis" : {
+    "analysis": {
       "filter": {
         "english_stop": {
-          "type":       "stop",
-          "stopwords":  "_english_"},
+          "type": "stop",
+          "stopwords": "_english_"
+        },
         "english_keywords": {
-          "type":       "keyword_marker",
-          "keywords":   []},
+          "type": "keyword_marker",
+          "keywords": []
+        },
         "english_stem": {
-          "type":       "stemmer",
-          "language":   "english"},
+          "type": "stemmer",
+          "language": "english"
+        },
         "english_possessive_stem": {
-          "type":       "stemmer",
-          "language":   "possessive_english"},
+          "type": "stemmer",
+          "language": "possessive_english"
+        },
         "my_bigram_filter": {
           "type": "shingle",
           "max_shingle_size": 2,
           "min_shingle_size": 2,
-          "output_unigrams": false}
+          "output_unigrams": false
+        }
       },
       "analyzer": {
         "my_english": {
-            "type": "custom",
-            "char_filter": ["html_strip"],
-            "tokenizer": "whitespace",
-            "filter":  ["lowercase", 
-                         "english_possessive_stem",
-                         "english_stop",
-                         "english_keywords",
-                         "english_stem"]
-  }}},
-  "number_of_shards": 1
+          "type": "custom",
+          "char_filter": [
+            "html_strip"
+          ],
+          "tokenizer": "whitespace",
+          "filter": [
+            "lowercase",
+            "english_possessive_stem",
+            "english_stop",
+            "english_keywords",
+            "english_stem"
+          ]
+        }
+      }
+    },
+    "number_of_shards": 1
+  }
 }
-}
-


### PR DESCRIPTION
From "Think Like A Relevance Engineer (Elasticsearch) Welcome Letter" by @binarymax and @renekrie:
> To get the most out of the training, we encourage you to install Elasticsearch 7.4 and the TMDB index per the Github link below. [...] (link to this repo)

The problem is that the code in this repo is meant to be used with ES 6.4.1. This PR upgrades ES and Kibana to 7.3.1, only because there are no LTR plugin builds for the latest version (7.4.1 at the the moment) on http://es-learn-to-rank.labs.o19s.com/ page.