### PR TITLE
upgrade ES and Kibana - 7.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Give it a minute to fully boot up then use a browser to go to http://localhost:9
 
 ### Elasticsearch
 
-1. Download [Elasticsearch 7.6.2](https://www.elastic.co/downloads/past-releases/elasticsearch-7-6-2)
+1. Download [Elasticsearch 7.16.2](https://www.elastic.co/downloads/past-releases/elasticsearch-7-16-2)
 2. Unzip to where you'd like to run Elasticsearch
 3. Add the following to config/elasticsearch.yml
 
@@ -55,7 +55,7 @@ bin/elasticsearch
 
 ### Kibana
 
-1. Download [Kibana 7.6.2](https://www.elastic.co/downloads/past-releases/kibana-7-6-2)
+1. Download [Kibana 7.16.2](https://www.elastic.co/downloads/past-releases/kibana-7-16-2)
 
 2. Unzip to where you'd like to run Kibana
 

--- a/es-docker/Dockerfile
+++ b/es-docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
 
-RUN bin/elasticsearch-plugin install -b http://es-learn-to-rank.labs.o19s.com/ltr-1.2.1-es7.6.2.zip
-RUN bin/elasticsearch-plugin install -b "https://repo1.maven.org/maven2/org/querqy/querqy-elasticsearch/1.2.es762.0/querqy-elasticsearch-1.2.es762.0.zip"
+RUN bin/elasticsearch-plugin install -b https://github.com/o19s/elasticsearch-learning-to-rank/releases/download/v1.5.8-es7.16.2/ltr-plugin-v1.5.8-es7.16.2.zip
+RUN bin/elasticsearch-plugin install -b "https://repo1.maven.org/maven2/org/querqy/querqy-elasticsearch/1.5.es7162.0/querqy-elasticsearch-1.5.es7162.0.zip"
 COPY --chown=elasticsearch:elasticsearch elasticsearch.yml /usr/share/elasticsearch/config/
 RUN cat  /usr/share/elasticsearch/config/elasticsearch.yml
 

--- a/kb-docker/Dockerfile
+++ b/kb-docker/Dockerfile
@@ -1,4 +1,4 @@
 FROM docker.elastic.co/kibana/kibana:7.16.2
 
-#RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.6.2/analyze_api_ui-7.6.2.zip
+RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.16.2/analyzeApiUi-7.16.2.zip
 

--- a/kb-docker/Dockerfile
+++ b/kb-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/kibana/kibana:7.6.2
+FROM docker.elastic.co/kibana/kibana:7.16.2
 
-RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.6.2/analyze_api_ui-7.6.2.zip
+#RUN ./bin/kibana-plugin install https://github.com/johtani/analyze-api-ui-plugin/releases/download/7.6.2/analyze_api_ui-7.6.2.zip
 


### PR DESCRIPTION
This fixes Elasticsearch and Kibana on M1 macs. However https://github.com/johtani/analyze-api-ui-plugin won't work due to https://github.com/johtani/analyze-api-ui-plugin/issues/48 (even though that plugin is still listed here https://www.elastic.co/guide/en/kibana/current/kibana-plugins.html)

The error message you get on an M1 Mac is similar to the following from Elasticsearch:

```
elasticsearch_1 |Exception in thread "main" java.io.IOException: Cannot run program "/usr/share/elasticsearch/jdk/bin/java": error=0, Failed to exec spawn helper.
elasticsearch_1 |	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1128)
elasticsearch_1 |	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1071)
elasticsearch_1 |	at org.elasticsearch.tools.launchers.JvmErgonomics.flagsFinal(JvmErgonomics.java:111)
elasticsearch_1 |	at org.elasticsearch.tools.launchers.JvmErgonomics.finalJvmOptions(JvmErgonomics.java:88)
elasticsearch_1 |	at org.elasticsearch.tools.launchers.JvmErgonomics.choose(JvmErgonomics.java:59)
elasticsearch_1 |	at org.elasticsearch.tools.launchers.JvmOptionsParser.main(JvmOptionsParser.java:95)
elasticsearch_1 |Caused by: java.io.IOException: error=0, Failed to exec spawn helper.
elasticsearch_1 |	at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
elasticsearch_1 |	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:319)
elasticsearch_1 |	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:250)
elasticsearch_1 |	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1107)
elasticsearch_1 |	... 5 more
```